### PR TITLE
Fixing identification of valid intersection

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -485,7 +485,7 @@
 			//iterate all valid intersections and check if point already exists, if not push to valid intersections
 			if (validInters.length > 0) {
 				for (var j = 1; j < validInters.length; j++) {
-					if (!(Math.abs(validInters[j].x - p.x) > d && Math.abs(validInters[j].y - p.y) > d)) {
+					if((Math.abs(validInters[j].x - p.x) < d && Math.abs(validInters[j].y - p.y) < d)) {
 						valid = false;
 						break;
 					}


### PR DESCRIPTION
When any two intersecion points have the same x coordinate or the same y coordinate it would fail. The check is valid if both the x and y coordinate of both intersections are too close instead of either.
