### PR TITLE
Fix: handle paths that share a starting point

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -206,8 +206,19 @@
 	 * @returns void
 	 */
 	var markSubpathEndings = function() {
-		var subPaths = 0, //store overall number of existing subpaths (for id generation)
+		var currentId, //id of the current path's starting point
+			markedCount = 0,
+			markedPoints = [],
 			path;
+
+		//generate a unique id for unknown points
+		function findOrCreateId(x, y) {
+			var id = markedPoints[[x, y]];
+			if (id) {
+				return id;
+			}
+			return markedPoints[[x, y]] = "S" + markedCount++;
+		}
 
 		//iterate paths
 		for (var i = 0; i < arguments.length; i++) {
@@ -216,15 +227,16 @@
 			for (var j = 0; j < path.length; j++) {
 				//first segment of a path has always starting point of subpath
 				if (j === 0) {
-					path[j].startPoint = "S" + subPaths;
+					currentId = findOrCreateId(path[j][0], path[j][1]);
+					path[j].startPoint = currentId;
 				}
 
 				//if ending point of a segment is different from starting  point of next seg. mark both
 				if (j < path.length - 1) {
 					if (path[j][6] != path[j + 1][0] || path[j][7] != path[j + 1][1]) {
-						path[j].endPoint = "S" + subPaths;
-						subPaths++;
-						path[j + 1].startPoint = "S" + subPaths;
+						path[j].endPoint = currentId;
+						currentId = findOrCreateId(path[j + 1][0], path[j + 1][1]);
+						path[j + 1].startPoint = currentId;
 					}
 				}
 
@@ -232,8 +244,7 @@
 
 				//last segment of a path has always ending point of subpath
 				if (j == path.length - 1) {
-					path[j].endPoint = "S" + subPaths;
-					subPaths++;
+					path[j].endPoint = currentId;
 				}
 			}
 		}

--- a/test/bug-shared-start.html
+++ b/test/bug-shared-start.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Raphael.boolean shared start point bug</title>
+	</head>
+	<body>
+		<script src="./../raphael-min.js"></script>
+		<script src="./../raphael.boolean.js"></script>
+		<script>
+			["union", "difference", "intersection", "exclusion"].forEach(function(type) {
+				var h2 = document.body.appendChild(document.createElement("h2"));
+				h2.innerText = type;
+
+				var div = document.body.appendChild(document.createElement("div"));
+				div.id = type;
+
+				var paper = Raphael(type, 350, 150);
+
+				var path1 = paper.path("M 100,0 L60,120 L140,40 Z");
+				path1.attr({fill: "#a00", stroke: "none"});
+
+				var path2 = paper.path("M 100,0 L140,120 L60,40 Z");
+				path2.attr({fill: "#0a0", stroke: "none"});
+
+				var booleanStr = paper[type](path1, path2);
+				var booleanPath = paper.path(booleanStr);
+				booleanPath.attr({fill: "#00a", stroke: "none"});
+				booleanPath.transform("t150,0");
+			});
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
The library gets confused when both paths share a starting point and throws an exception.

This PR provides both a fix (keeping track of starting points to avoid creating duplicate IDs) and a unit test that demonstrates the bug.