### PR TITLE
Fix toPath() behaviour for circles and ellipses.

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -183,14 +183,14 @@
 				path.push(["C", c1[0], c1[1], c2[0], c2[1], p2[0], p2[1]]);
 			}
 
-			if (i < 3) {
-				//if it's a rectangle draw line to next corner (point)
-				if (el.type == "rect") {
+			//if it's a rectangle draw line to next corner (point)
+			if (el.type == "rect") {
+				if (i < 3) {
 					var p1 = [cornerPoints[i + 1][0] + radiusShift[i + 1][0][0] * rx, cornerPoints[i + 1][1] + radiusShift[i + 1][0][1] * ry];
 					path.push(["L", p1[0], p1[1]]);
+				} else {
+					path.push(["Z"]);
 				}
-			} else {
-				path.push(["Z"]);
 			}
 		}
 


### PR DESCRIPTION
The `toPath()` function was unconditionally adding a `Z` instruction at the end of the path. This instruction inserts a zero-length segment inside circle and ellipse paths and should only be used for rectangles.

Example:

```js
paper.toPath(paper.circle(0,0,100)).replace(/[A-Z]/g,'\n$&');
`
M-100,0
C-100,-55.4,-55.4,-100,0,-100
C55.4,-100,100,-55.4,100,0
C100,55.4,55.4,100,0,100
C-55.4,100,-100,55.4,-100,0
Z`
```

Note the extra `Z` at the end. The endpoint is already at `-100,0`.