### PR TITLE
Use “rx” and “ry” attributes of rect nodes instead of “r”.

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -119,8 +119,8 @@
 
 		switch (el.type) {
 			case "rect":
-				var rx = a.r,
-					ry = a.r,
+				var rx = a.rx || a.r || 0,
+					ry = a.ry || a.r || 0,
 					cornerPoints = [
 						[a.x, a.y],
 						[a.x + a.width, a.y],


### PR DESCRIPTION
The invalid “r” attribute was removed from Raphaël in the following commit:
   https://github.com/DmitryBaranovskiy/raphael/commit/355104d4

For backwards compatibility we still look for a.r when a.rx or a.ry are not found.