### PR TITLE
Optimise exclusion operation.

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -835,7 +835,8 @@
 	var exclusion = function(el1, el2) {
 		var pathA = prepare(el1),
 			pathB = prepare(el2);
-		return pathSegsToStr(execBO("difference", execBO("union", pathA, pathB), execBO("intersection", pathA, pathB)));
+		return pathSegsToStr(execBO("difference", pathA, pathB))
+			+ pathSegsToStr(execBO("difference", pathB, pathA));
 	};
 
 	//add public methods to Raphael


### PR DESCRIPTION
Currently exclusion is computed as (A∪B)-(A∩B). This change computes it as (A-B)∪(B-A) instead. Because the two shapes A-B and B-A are obviously disjoint, the final union can be just a string concatenation. This is more efficient and also more robust because the final difference operation was detecting a great number of intersections caused by common vertices.