### PR TITLE
Add explicit random jitter to intersection checks.

### DIFF
--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -339,7 +339,11 @@
 		var point = Raphael.findDotsAtSegment(seg[0], seg[1], seg[2], seg[3], seg[4], seg[5], seg[6], seg[7], 0.5);
 
 		//is point inside of given path
-		return Raphael.isPointInsidePath(path, point.x, point.y);
+		var bbox = Raphael.pathBBox(path);
+		var dx = bbox.width * 1.1;
+		var dy = bbox.height * Math.random() / 100;
+		return Raphael.isPointInsideBBox(bbox, point.x, point.y) &&
+			Raphael.pathIntersectionNumber(path, [["M", point.x, point.y], ["l", dx, dy]], 1) % 2 == 1;
 	};
 
 	/**
@@ -429,7 +433,7 @@
 
 		//"draw" a horizontal line from left to right at half height of path's bbox
 		var lineY = box.y + box.height / 2;
-		var line = ("M" + box.x + "," + lineY + "L" + box.x2 + "," + lineY);
+		var line = ("M" + box.x + "," + lineY + "l" + box.width + "," + box.height * Math.random() / 100);
 
 		//get intersections of line and path
 		var inters = Raphael.pathIntersection(line, path);

--- a/raphael.boolean.js
+++ b/raphael.boolean.js
@@ -431,9 +431,11 @@
 		var path = pathSegsToStr(pathSegArr);
 		var box = Raphael.pathBBox(path);
 
-		//"draw" a horizontal line from left to right at half height of path's bbox
+		//"draw" a horizontal line from left to right at half height of path's bbox,
+		//with some jitter to avoid intersecting at exact vertices.
 		var lineY = box.y + box.height / 2;
-		var line = ("M" + box.x + "," + lineY + "l" + box.width + "," + box.height * Math.random() / 100);
+		var line = ("M" + box.x + "," + (lineY - box.height * Math.random() / 100)
+			 + "L" + box.x2 + "," + (lineY + box.height * Math.random() / 100));
 
 		//get intersections of line and path
 		var inters = Raphael.pathIntersection(line, path);
@@ -449,13 +451,11 @@
 		}
 
 		//decide, if path is clockwise (1) or counter clockwise (-1)
-		if (startY < lineY && inters[minT].segment2 >= inters[maxT].segment2 || startY > lineY && inters[minT].segment2 <= inters[maxT].segment2) {
+		if ((startY < lineY) == (inters[minT].segment2 >= inters[maxT].segment2)) {
 			//for path with only one segment compare t
-			if (inters[minT].segment2 == inters[maxT].segment2) {
-				if (startY < lineY && inters[minT].t2 >= inters[maxT].t2 || startY > lineY && inters[minT].t2 <= inters[maxT].t2) {
-					dir = 1;
-				}
-			} else {
+			if (inters[minT].segment2 != inters[maxT].segment2) {
+				dir = 1;
+			} else if ((startY < lineY) == (inters[minT].t2 >= inters[maxT].t2)) {
 				dir = 1;
 			}
 		}


### PR DESCRIPTION
This works around a Raphael.isPointInsidePath limitation. There was a workaround mentioned in https://github.com/poilu/raphael-boolean/issues/3#issuecomment-20426463 but it is vulnerable to corner cases. A fix was also proposed upstream at https://github.com/DmitryBaranovskiy/raphael/pull/1131